### PR TITLE
Fixed compilation with GHC 7.6.*

### DIFF
--- a/equivalence.cabal
+++ b/equivalence.cabal
@@ -39,7 +39,7 @@ Test-Suite test
 
 Library
   Build-Depends:
-    base >= 4 && < 5, containers, mtl >= 2.0.1, STMonadTrans >= 0.4.1,
+    base >= 4 && < 5, containers, mtl >= 2.0.1, STMonadTrans >= 0.4.3,
     transformers >= 0.2, transformers-compat >= 0.3
   Exposed-Modules:
     Data.Equivalence.STT,


### PR DESCRIPTION
The equivalence library doesn't compile with GHC 7.6.3 when using STMonadTrans 0.4.1 because this version of STMonadTrans doesn't support GHC 7.6.3 (see https://github.com/josefs/STMonadTrans/issues/11).

The above issue was fixed in STMonadTrans [0.4.3](http://hackage.haskell.org/package/STMonadTrans-0.4.3).

This PR fix the problem by bumping the upper lower bound of STMonadTrans.