### PR TITLE
Fixed compilation with GHC 8.8.1.

### DIFF
--- a/src/Data/Equivalence/Monad.hs
+++ b/src/Data/Equivalence/Monad.hs
@@ -233,7 +233,7 @@ class (Monad m, Applicative m, Ord v) => MonadEquiv c v d m | m -> v, m -> c, m 
 
                                      
 
-instance (Monad m, Applicative m, Ord v) => MonadEquiv (Class s d v) v d (EquivT s d v m) where
+instance (Fail.MonadFail m, Applicative m, Ord v) => MonadEquiv (Class s d v) v d (EquivT s d v m) where
     equivalent x y = EquivT $ do
       part <- ask
       lift $ S.equivalent part x y

--- a/src/Data/Equivalence/STT.hs
+++ b/src/Data/Equivalence/STT.hs
@@ -62,6 +62,7 @@ module Data.Equivalence.STT
 import Control.Monad.ST.Trans
 import Control.Monad
 import Control.Applicative
+import qualified Control.Monad.Fail as Fail
 
 import Data.Maybe
 
@@ -246,7 +247,7 @@ the equivalence classes of the two elements and combines their
 descriptor. The returned entry is the representative of the new
 equivalence class -}
 
-equateEntry :: (Monad m, Applicative m, Ord a) => Equiv s c a -> Entry s c a -> Entry s c a -> STT s m (Entry s c a)
+equateEntry :: (Fail.MonadFail m, Applicative m, Ord a) => Equiv s c a -> Entry s c a -> Entry s c a -> STT s m (Entry s c a)
 equateEntry Equiv {combDesc = mkDesc} repx@(Entry rx) repy@(Entry ry) = 
   if (rx /= ry) then do
     dx <- readSTRef rx
@@ -267,7 +268,7 @@ equateEntry Equiv {combDesc = mkDesc} repx@(Entry rx) repy@(Entry ry) =
       _ -> fail "error on `equateEntry`"
   else return  repx
 
-combineEntries :: (Monad m, Applicative m, Ord a)
+combineEntries :: (Fail.MonadFail m, Applicative m, Ord a)
                => Equiv s c a -> [b] -> (b -> STT s m (Entry s c a)) -> STT s m ()
 combineEntries  _ [] _ = return ()
 combineEntries eq (e:es) rep = do
@@ -284,7 +285,7 @@ combineEntries eq (e:es) rep = do
 list. Afterwards all elements in the argument list represent the same
 equivalence class! -}
 
-combineAll :: (Monad m, Applicative m, Ord a) => Equiv s c a -> [Class s c a] -> STT s m ()
+combineAll :: (Fail.MonadFail m, Applicative m, Ord a) => Equiv s c a -> [Class s c a] -> STT s m ()
 combineAll eq cls = combineEntries eq cls (classRep eq)
 
 
@@ -293,7 +294,7 @@ classes. Afterwards both arguments represent the same equivalence
 class! One of it is returned in order to represent the new combined
 equivalence class. -}
 
-combine :: (Monad m, Applicative m, Ord a) => Equiv s c a -> Class s c a -> Class s c a -> STT s m (Class s c a)
+combine :: (Fail.MonadFail m, Applicative m, Ord a) => Equiv s c a -> Class s c a -> Class s c a -> STT s m (Class s c a)
 combine eq x y = combineAll eq [x,y] >> return x
 
 
@@ -301,14 +302,14 @@ combine eq x y = combineAll eq [x,y] >> return x
 unions the equivalence classes of the elements and combines their
 descriptor. -}
 
-equateAll :: (Monad m, Applicative m, Ord a) => Equiv s c a -> [a] -> STT s m ()
+equateAll :: (Fail.MonadFail m, Applicative m, Ord a) => Equiv s c a -> [a] -> STT s m ()
 equateAll eq cls = combineEntries eq cls (representative eq)
 
 {-| This function equates the two given elements. That is, it unions
 the equivalence classes of the two elements and combines their
 descriptor. -}
 
-equate :: (Monad m, Applicative m, Ord a) => Equiv s c a -> a -> a -> STT s m ()
+equate :: (Fail.MonadFail m, Applicative m, Ord a) => Equiv s c a -> a -> a -> STT s m ()
 equate eq x y = equateAll eq [x,y]
 
 


### PR DESCRIPTION
GHC 8.8.1 was [released](https://mail.haskell.org/pipermail/ghc-devs/2019-August/018050.html). In this PR I fixed the compilation with this version of GHC.

Blocking https://github.com/agda/agda/issues/3725.