### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/equivalence.cabal
+++ b/equivalence.cabal
@@ -34,7 +34,9 @@ Test-Suite test
   Other-Modules:	Data.Equivalence.Monad_Test,Data.Equivalence.Monad, Data.Equivalence.STT
   hs-source-dirs:	src testsuite/tests
   Build-Depends:        base >= 4, template-haskell, containers, mtl >= 2.0.1, QuickCheck >= 2,
-                        STMonadTrans >= 0.4.3, transformers >= 0.2, transformers-compat >= 0.3, fail
+                        STMonadTrans >= 0.4.3, transformers >= 0.2, transformers-compat >= 0.3
+  if impl(ghc < 8.0)
+    Build-Depends: fail
 
 Library
   Build-Depends:
@@ -44,4 +46,5 @@ Library
     Data.Equivalence.STT,
     Data.Equivalence.Monad
   Hs-Source-Dirs: src
-  build-depends: fail
+  if impl(ghc < 8.0)
+    Build-Depends: fail


### PR DESCRIPTION
They are not needed on newer GHC.