### PR TITLE
Haddocks: update copyright etc.

### DIFF
--- a/src/Data/Equivalence/Monad.hs
+++ b/src/Data/Equivalence/Monad.hs
@@ -10,11 +10,11 @@
 -- |
 -- Module      : Data.Equivalence.Monad
 -- Copyright   : Patrick Bahr, 2010
--- License     : All Rights Reserved
+-- License     : BSD-3-Clause
 --
--- Maintainer  :  Patrick Bahr
--- Stability   :  unknown
--- Portability :  unknown
+-- Maintainer  :  Patrick Bahr, Andreas Abel
+-- Stability   :  stable
+-- Portability :  non-portable (MPTC with FD)
 --
 -- This is an alternative interface to the union-find implementation
 -- in ''Data.Equivalence.STT''. It is wrapped into the monad

--- a/src/Data/Equivalence/STT.hs
+++ b/src/Data/Equivalence/STT.hs
@@ -3,7 +3,7 @@
 --------------------------------------------------------------------------------
 -- |
 -- Module      : Data.Equivalence.STT
--- Copyright   : 3gERP, 2010
+-- Copyright   : Patrick Bahr, 2010
 -- License     : BSD-3-Clause
 --
 -- Maintainer  :  Patrick Bahr, Andreas Abel

--- a/src/Data/Equivalence/STT.hs
+++ b/src/Data/Equivalence/STT.hs
@@ -4,11 +4,11 @@
 -- |
 -- Module      : Data.Equivalence.STT
 -- Copyright   : 3gERP, 2010
--- License     : All Rights Reserved
+-- License     : BSD-3-Clause
 --
--- Maintainer  :  Patrick Bahr
--- Stability   :  unknown
--- Portability :  unknown
+-- Maintainer  :  Patrick Bahr, Andreas Abel
+-- Stability   :  stable
+-- Portability :  non-portable (MPTC)
 --
 -- This is an implementation of Tarjan's Union-Find algorithm (Robert
 -- E. Tarjan. "Efficiency of a Good But Not Linear Set Union


### PR DESCRIPTION
The .cabal file says that the license is BSD-3-Clause, this should be also stated as such in the haddocks.

Rendering here: https://hackage.haskell.org/package/equivalence-0.4/candidate/docs/Data-Equivalence-STT.html

In the Copyright tag: 3gERP seems to have been a project (Google still returns some traces).  Should this be changed to _Patrick Bahr_?