### PR TITLE
Release 0.4

### DIFF
--- a/src/Data/Equivalence/Monad.hs
+++ b/src/Data/Equivalence/Monad.hs
@@ -99,12 +99,13 @@ equivalence relation. The first two arguments specify how to construct
 an equivalence class descriptor for a singleton class and how to
 combine two equivalence class descriptors. -}
 
-runEquivT :: (Monad m, Applicative m)
-          => (v -> c) -- ^ used to construct an equivalence class descriptor for a singleton class
-          -> (c -> c -> c) -- ^ used to combine the equivalence class descriptor of two classes
-                           --   which are meant to be combined.
-          -> (forall s. EquivT s c v m a)
-          -> m a
+runEquivT
+  :: (Monad m, Applicative m)
+  => (v -> c)      -- ^ Used to construct an equivalence class descriptor for a singleton class.
+  -> (c -> c -> c) -- ^ Used to combine the equivalence class descriptor of two classes
+                   --   which are meant to be combined.
+  -> (forall s. EquivT s c v m a)
+  -> m a
 runEquivT mk com m = runSTT $ do
   p <- leastEquiv mk com
   (`runReaderT` p) $ unEquivT m
@@ -120,11 +121,13 @@ runEquivT' = runEquivT (const ()) (\_ _-> ())
 equivalence relation. The first tow arguments specify how to construct
 an equivalence class descriptor for a singleton class and how to
 combine two equivalence class descriptors. -}
-runEquivM :: (v -> c) -- ^ used to construct an equivalence class descriptor for a singleton class
-          -> (c -> c -> c) -- ^ used to combine the equivalence class descriptor of two classes
-                           --   which are meant to be combined.
-          -> (forall s. EquivM s c v a)
-          -> a
+
+runEquivM
+  :: (v -> c)      -- ^ Used to construct an equivalence class descriptor for a singleton class.
+  -> (c -> c -> c) -- ^ Used to combine the equivalence class descriptor of two classes
+                   --   which are meant to be combined.
+  -> (forall s. EquivM s c v a)
+  -> a
 runEquivM sing comb m = runIdentity $ runEquivT sing comb m
 
 {-| This function is a special case of 'runEquivM' that only maintains
@@ -139,7 +142,7 @@ maintains an equivalence relation.  -}
 class (Monad m, Applicative m, Ord v) => MonadEquiv c v d m | m -> v, m -> c, m -> d where
 
     {-| This function decides whether the two given elements are
-        equivalent in the current equivalence relation -}
+        equivalent in the current equivalence relation. -}
 
     equivalent :: v -> v -> m Bool
 
@@ -166,8 +169,7 @@ class (Monad m, Applicative m, Ord v) => MonadEquiv c v d m | m -> v, m -> c, m 
 
     removeClass :: v -> m Bool
 
-    {-| This function provides the equivalence class the given element
-      is contained in. -}
+    {-| This function provides the equivalence class of the given element. -}
 
     getClass :: v -> m c
 
@@ -196,7 +198,7 @@ class (Monad m, Applicative m, Ord v) => MonadEquiv c v d m | m -> v, m -> c, m 
     desc :: c -> m d
 
     {-| This function removes the given equivalence class. If the
-      equivalence class does not exists anymore @False@ is returned;
+      equivalence class does not exist anymore, @False@ is returned;
       otherwise @True@. -}
 
     remove :: c -> m Bool

--- a/src/Data/Equivalence/STT.hs
+++ b/src/Data/Equivalence/STT.hs
@@ -67,8 +67,9 @@ import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map as Map
 
-newtype Class s c a = Class (STRef s (Entry s c a))
+{-| Abstract representation of an equivalence class. -}
 
+newtype Class s c a = Class (STRef s (Entry s c a))
 
 {-| This type represents a reference to an entry in the tree data
 structure. An entry of type 'Entry' @s c a@ lives in the state space
@@ -101,30 +102,30 @@ lives in the state space indexed by @s@, contains equivalence class
 descriptors of type @c@ and has elements of type @a@. -}
 
 data Equiv s c a = Equiv {
-      -- | maps elements to their entry in the tree data structure
+      -- | Maps elements to their entry in the tree data structure.
       entries :: Entries s c a,
-      -- | constructs an equivalence class descriptor for a singleton class
+      -- | Constructs an equivalence class descriptor for a singleton class.
       singleDesc :: a -> c,
-      -- | combines the equivalence class descriptor of two classes
+      -- | Combines the equivalence class descriptor of two classes
       --   which are meant to be combined.
       combDesc :: c -> c -> c
       }
 
 {-| This function constructs the initial data structure for
-maintaining an equivalence relation. That is it represents, the fines
+maintaining an equivalence relation. That is, it represents the finest
 (or least) equivalence class (of the set of all elements of type
 @a@). The arguments are used to maintain equivalence class
 descriptors. -}
 
-leastEquiv :: (Monad m, Applicative m)
-           => (a -> c) -- ^ used to construct an equivalence class descriptor for a singleton class
-           -> (c -> c -> c) -- ^ used to combine the equivalence class descriptor of two classes
-                            --   which are meant to be combined.
-           -> STT s m (Equiv s c a)
+leastEquiv
+  :: (Monad m, Applicative m)
+  => (a -> c)      -- ^ Used to construct an equivalence class descriptor for a singleton class.
+  -> (c -> c -> c) -- ^ Used to combine the equivalence class descriptor of two classes
+                   --   which are meant to be combined.
+  -> STT s m (Equiv s c a)
 leastEquiv mk com = do
   es <- newSTRef Map.empty
   return Equiv {entries = es, singleDesc = mk, combDesc = com}
-
 
 
 {-| This function returns the representative entry of the argument's
@@ -367,7 +368,7 @@ removeEntry (Entry r) = modifySTRef r change
 
 
 {-| This function removes the given equivalence class. If the
-equivalence class does not exists anymore @False@ is returned;
+equivalence class does not exist anymore, @False@ is returned;
 otherwise @True@. -}
 
 remove :: (Monad m, Applicative m, Ord a) => Equiv s c a -> Class s c a -> STT s m Bool


### PR DESCRIPTION
I did some cosmetic fixes on the documentation (capitalization, dotting, typos).
Updated candidate at: https://hackage.haskell.org/package/equivalence-0.4/candidate

There is an open PR remaining (#13), but this needs revision and it is not clear if the author will pick it up again.

I'd say we could release 0.4 (unless you want to await the publication of `mtl-2.3`).

Let me know when you want me to push the release button.

