### PR TITLE
equivalence 0.4.0.1: add LANGUAGE TypeOperators for GHC 9.4

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,18 +8,22 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14
+# version: 0.15.20220525
 #
-# REGENDATA ("0.14",["github","equivalence.cabal"])
+# REGENDATA ("0.15.20220525",["github","equivalence.cabal"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,9 +32,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.1
+          - compiler: ghc-9.4.0.20220501
             compilerKind: ghc
-            compilerVersion: 9.2.1
+            compilerVersion: 9.4.0.20220501
+            setup-method: ghcup
+            allow-failure: true
+          - compiler: ghc-9.2.2
+            compilerKind: ghc
+            compilerVersion: 9.2.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2
@@ -81,8 +90,9 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            if $HEADHACKAGE; then "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml; fi
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           else
@@ -90,7 +100,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.8/x86_64-linux-ghcup-0.1.17.8 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
@@ -123,7 +133,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -152,6 +162,17 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -203,6 +224,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(equivalence)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -235,8 +259,15 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set mtl-2.3
+        run: |
+          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3' --constraint='transformers >= 0.6' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3' --constraint='transformers >= 0.6' all ; fi

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dummy.cabal
 hpcreport
 *.tix
 *.log
+/dist-newstyle/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,22 @@
+0.4.0.1
+-------
+
+_Andreas Abel, 2022-05-26_
+
+* add `LANGUAGE TypeOperators` for GHC 9.4
+
 0.4
 ---
+
+_Andreas Abel, 2022-02-03_
+
 * remove ErrorT instance for compatibility with transformers-0.6 and mtl-2.3
 
 0.3.5
 -----
+
+_Patrick Bahr, 2019-09-09_
+
 * compatibility with GHC 8.8
 
 0.3.4

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,0 +1,5 @@
+branches: master
+
+constraint-set mtl-2.3
+  ghc: >= 8.6
+  constraints: mtl >= 2.3, transformers >= 0.6

--- a/equivalence.cabal
+++ b/equivalence.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:   >= 1.10
 Name:            equivalence
-Version:         0.4
+Version:         0.4.0.1
 License:         BSD3
 License-File:    LICENSE
 Author:          Patrick Bahr
@@ -21,15 +21,16 @@ Stability:       provisional
 Build-Type:      Simple
 
 tested-with:
-  GHC == 7.10.3
-  GHC == 8.0.2
-  GHC == 8.2.2
-  GHC == 8.4.4
-  GHC == 8.6.5
-  GHC == 8.8.4
-  GHC == 8.10.7
+  GHC == 9.4.1
+  GHC == 9.2.2
   GHC == 9.0.2
-  GHC == 9.2.1
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
+  GHC == 8.2.2
+  GHC == 8.0.2
+  GHC == 7.10.3
 
 Extra-Source-Files: CHANGES.md
 

--- a/src/Data/Equivalence/Monad.hs
+++ b/src/Data/Equivalence/Monad.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-} -- for type equality ~
+{-# LANGUAGE TypeOperators #-} -- for type equality ~ with GHC 9.4
 {-# LANGUAGE UndecidableInstances #-}
 
 --------------------------------------------------------------------------------
@@ -92,7 +93,7 @@ instance Monad m => Fail.MonadFail (EquivT s c v m) where
 -- because EquivT already contains a ReaderT in its monad transformer stack.
 instance (MonadReader r m) => MonadReader r (EquivT s c v m) where
     ask = EquivT $ lift ask
-    local f (EquivT (ReaderT m)) = EquivT $ ReaderT $ (\ r -> local f (m r))
+    local f (EquivT (ReaderT m)) = EquivT $ ReaderT $ \ r -> local f (m r)
 
 {-| This function runs a monadic computation that maintains an
 equivalence relation. The first two arguments specify how to construct


### PR DESCRIPTION
Published at: https://hackage.haskell.org/package/equivalence-0.4.0.1