### PR TITLE
v0.4.1.1: bump cabal-version to 1.18, remove unused dependencies

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250506",["github","equivalence.cabal"])
+# REGENDATA ("0.19.20250821",["github","equivalence.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.0.20250819
+            compilerKind: ghc
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -110,11 +115,26 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -136,7 +156,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -164,6 +184,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -212,9 +244,16 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_equivalence}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package equivalence" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package equivalence" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package equivalence" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(equivalence)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -252,15 +291,6 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
-      - name: prepare for constraint sets
-        run: |
-          rm -f cabal.project.local
-      - name: constraint set mtl-2.3
-        run: |
-          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3' --constraint='transformers >= 0.6' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3' --constraint='transformers >= 0.6' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80600)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --constraint='mtl >= 2.3' --constraint='transformers >= 0.6' all ; fi
       - name: save cache
         if: always()
         uses: actions/cache/save@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+0.4.1.1
+-------
+
+_Andreas Abel, 2025-08-27_
+
+- bump cabal-version to 1.18
+- remove unused dependencies
+
+Tested with GHC 8.0 - 9.14 alpha1
+
 0.4.1
 -----
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,5 +1,5 @@
 branches: master
 
-constraint-set mtl-2.3
-  ghc: >= 8.6
-  constraints: mtl >= 2.3, transformers >= 0.6
+-- constraint-set mtl-2.3
+--   ghc: >= 8.6
+--   constraints: mtl >= 2.3, transformers >= 0.6

--- a/equivalence.cabal
+++ b/equivalence.cabal
@@ -1,6 +1,6 @@
-Cabal-Version:   >= 1.10
+Cabal-Version:   1.18
 Name:            equivalence
-Version:         0.4.1
+Version:         0.4.1.1
 License:         BSD3
 License-File:    LICENSE
 Author:          Patrick Bahr
@@ -21,6 +21,7 @@ Stability:       provisional
 Build-Type:      Simple
 
 tested-with:
+  GHC == 9.14.1
   GHC == 9.12.2
   GHC == 9.10.2
   GHC == 9.8.4
@@ -35,7 +36,7 @@ tested-with:
   GHC == 8.2.2
   GHC == 8.0.2
 
-Extra-Source-Files: CHANGES.md
+Extra-Doc-Files: CHANGES.md
 
 source-repository head
   type:     git
@@ -50,16 +51,16 @@ Library
   default-language:     Haskell2010
   Build-Depends:
     base                   >= 4.9    && < 5
-    , containers
+    -- Lower bounds at least from Stackage LTS 7.0 (GHC 8.0)
+    , containers           >= 0.5.7.1
     , mtl                  >= 2.2.1
     , STMonadTrans         >= 0.4.3
-    , transformers         >= 0.2
-    , transformers-compat  >= 0.3
+    , transformers         >= 0.5.2.0
 
   ghc-options:
       -Wall
-      -fno-warn-name-shadowing
-      -fno-warn-incomplete-record-updates
+      -Wno-name-shadowing
+      -Wno-incomplete-record-updates
       -Wcompat
 
 Test-Suite test
@@ -79,15 +80,14 @@ Test-Suite test
     , mtl
     , STMonadTrans
     , transformers
-    , transformers-compat
     -- Additional dependencies for testsuite
-    , QuickCheck           >= 2
-    , template-haskell
+    -- Lower bounds at least from Stackage LTS 7.0 (GHC 8.0)
+    , QuickCheck           >= 2.8.2
 
   ghc-options:
       -Wall
-      -fno-warn-name-shadowing
-      -fno-warn-incomplete-record-updates
-      -fno-warn-missing-signatures
-      -fno-warn-unused-do-bind
+      -Wno-name-shadowing
+      -Wno-incomplete-record-updates
+      -Wno-missing-signatures
+      -Wno-unused-do-bind
       -Wcompat

--- a/src/Data/Equivalence/STT.hs
+++ b/src/Data/Equivalence/STT.hs
@@ -86,11 +86,12 @@ structure. Entry data of type 'EntryData' @s c a@ lives in the state space
 indexed by @s@, contains equivalence class descriptors of type @c@ and
 has elements of type @a@.  -}
 
-data EntryData s c a = Node {
+data EntryData s c a
+  = Node {
       entryParent :: Entry s c a,
       entryValue :: a
     }
-                     | Root {
+  | Root {
       entryDesc :: c,
       entryWeight :: Int,
       entryValue :: a,
@@ -236,13 +237,8 @@ equivalence relation representation or @Nothing@ if there is none,
 yet.  -}
 
 getEntry :: (Monad m, Applicative m, Ord a) => Equiv s c a -> a -> STT s m (Maybe (Entry s c a))
-getEntry Equiv { entries = mref} val = do
-  m <- readSTRef mref
-  case Map.lookup val m of
-    Nothing -> return Nothing
-    Just entry -> return $ Just entry
-
-
+getEntry Equiv{ entries = mref } val = do
+  Map.lookup val <$> readSTRef mref
 
 {-| This function equates the two given (representative) elements. That
 is, it unions the equivalence classes of the two elements and combines

--- a/testsuite/tests/Data/Equivalence/Monad_Test.hs
+++ b/testsuite/tests/Data/Equivalence/Monad_Test.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes, TemplateHaskell #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Data.Equivalence.Monad_Test where
 


### PR DESCRIPTION
Candidate: http://hackage.haskell.org/package/equivalence-0.4.1.1/candidate